### PR TITLE
organization and improved create-event performance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: dotnet lambda deploy-serverless --disable-interactive true -pl roommate-lambda --stack-name roommate-dev --s3-bucket roommate-deploy --region us-east-1
 
 workflows:
-  version: 2
+  version: 2.1
   build_test_deploy:
     jobs:
       - build

--- a/roommate-lambda/Function.fs
+++ b/roommate-lambda/Function.fs
@@ -23,42 +23,10 @@ type Functions() =
         |> Seq.map (|KeyValue|)
         |> Map.ofSeq
 
-    let readConfig () : LambdaConfiguration =
-        {
-            roommateConfig = readSecretFromEnv "roommateConfig" |> RoommateConfig.deserializeConfig
-            serviceAccountEmail = readSecretFromEnv "serviceAccountEmail"
-            serviceAccountPrivKey = readSecretFromEnv "serviceAccountPrivKey"
-            serviceAccountAppName = readSecretFromEnv "serviceAccountAppName"
-            mqttEndpoint = readSecretFromEnv "mqttEndpoint"
-            webhookUrl = readSecretFromEnv "webhookUrl"
-        }
-
-    let sendAnUpdate (boardId:string) (context:ILambdaContext) =
-
-        sprintf "Sending an update for %s" boardId |> context.Logger.LogLine
-
-        let config = readConfig()
-
-        let logFn = context.Logger.LogLine
-
-        boardId |> lookupCalendarForBoard config.roommateConfig
-                        |> function
-                            | None -> Error  "Unknown board"
-                            | Some calId -> Ok calId
-                        |> Result.bind (fetchEventsForCalendar logFn config)
-                        |> Result.bind (mapEventsToMessage)
-                        |> Result.bind (determineTopicsToPublishTo logFn config.roommateConfig)
-                        |> Result.bind (sendMessageToTopics logFn config.mqttEndpoint)
-                        |> function
-                            | Error e -> logFn e
-                            | _ -> ()
-        ()
-
     member __.Get (request: APIGatewayProxyRequest) (context: ILambdaContext) =
         let verificationCode = readSecretFromEnv "GOOGLE_VERIFICATION_CODE"
 
-        sprintf "Request: %s" request.Path
-        |> context.Logger.LogLine
+        sprintf "Request: %s" request.Path |> context.Logger.LogLine
 
         let htmlBody = sprintf
                         """
@@ -81,19 +49,21 @@ type Functions() =
     member __.CalendarUpdate (request: APIGatewayProxyRequest) (context: ILambdaContext) =
         sprintf "Request: %s" request.Path |> context.Logger.LogLine
 
-        let config = readConfig()
+        let config = FunctionImpls.readConfig()
 
         let logFn = context.Logger.LogLine
 
-        request.Headers |> Option.ofObj |> Option.map toMap
+        let maybeCalendarId =
+            request.Headers
+            |> Option.ofObj
+            |> Option.map toMap
             |> function
                 | None -> Error  "No headers."
                 | Some h -> Ok h
             |> Result.bind (calendarIdFromPushNotification logFn config)
-            |> Result.bind (fetchEventsForCalendar logFn config)
-            |> Result.bind (mapEventsToMessage)
-            |> Result.bind (determineTopicsToPublishTo logFn config.roommateConfig)
-            |> Result.bind (sendMessageToTopics logFn config.mqttEndpoint)
+
+        maybeCalendarId
+            |> Result.bind (FunctionImpls.sendAnUpdateToCal logFn)
             |> function
                 | Error e -> logFn e
                 | _ -> ()
@@ -105,9 +75,16 @@ type Functions() =
             Headers = dict [ ("Content-Type", "text/plain") ]
         )
 
+
+    member __.OnDeviceConnect (request: Messages.DeviceConnect) (context: ILambdaContext) =
+        sprintf "Device Connected! %s" (request.clientId) |> context.Logger.LogLine
+
+        FunctionImpls.sendAnUpdateToBoard request.clientId context.Logger.LogLine
+
     member __.UpdateRequest (request: Messages.UpdateRequest) (context: ILambdaContext) =
         sprintf "Updated requested for boardId %s" (request.boardId) |> context.Logger.LogLine
-        sendAnUpdate request.boardId context
+
+        FunctionImpls.sendAnUpdateToBoard request.boardId context.Logger.LogLine
 
     member __.ReservationRequest (request: Messages.ReservationRequest) (context: ILambdaContext) =
         let startTime = request.start |> TimeUtil.dateTimeFromUnixTime
@@ -115,7 +92,7 @@ type Functions() =
 
         sprintf "Reservation requested for boardId %s: %s -> %s" (request.boardId) (startTime.ToString()) (endTime.ToString()) |> context.Logger.LogLine
 
-        let config = readConfig()
+        let config = FunctionImpls.readConfig()
 
         let logFn = context.Logger.LogLine
 
@@ -129,14 +106,9 @@ type Functions() =
                             | _ -> ()
         ()
 
-    member __.OnDeviceConnect (request: Messages.DeviceConnect) (context: ILambdaContext) =
-        sprintf "Device Connected! %s" (request.clientId) |> context.Logger.LogLine
-
-        sendAnUpdate request.clientId context
-
     member __.RenewWebhooks (event:Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent) (context:ILambdaContext) =
         let logFn = context.Logger.LogLine
-        let config = readConfig()
+        let config = FunctionImpls.readConfig()
         logFn (sprintf "event: %s" (Newtonsoft.Json.JsonConvert.SerializeObject(event)))
         logFn (sprintf "context: %s" (Newtonsoft.Json.JsonConvert.SerializeObject(context)))
         logFn (sprintf "webhook URL: %s" config.webhookUrl)

--- a/roommate-lambda/Function.fs
+++ b/roommate-lambda/Function.fs
@@ -60,7 +60,7 @@ type Functions() =
             |> function
                 | None -> Error  "No headers."
                 | Some h -> Ok h
-            |> Result.bind (calendarIdFromPushNotification logFn config)
+            |> Result.bind (FunctionImpls.calendarIdFromPushNotification logFn config)
 
         maybeCalendarId
             |> Result.bind (FunctionImpls.sendAnUpdateToCal logFn)
@@ -90,11 +90,12 @@ type Functions() =
         let startTime = request.start |> TimeUtil.dateTimeFromUnixTime
         let endTime   = request.finish |> TimeUtil.dateTimeFromUnixTime
 
-        sprintf "Reservation requested for boardId %s: %s -> %s" (request.boardId) (startTime.ToString()) (endTime.ToString()) |> context.Logger.LogLine
+        let logFn = context.Logger.LogLine
+
+        sprintf "Reservation requested for boardId %s: %s -> %s" (request.boardId) (startTime.ToString()) (endTime.ToString()) |> logFn
 
         let config = FunctionImpls.readConfig()
 
-        let logFn = context.Logger.LogLine
 
         request.boardId |> lookupCalendarForBoard config.roommateConfig
                         |> function

--- a/roommate-lambda/Function.fs
+++ b/roommate-lambda/Function.fs
@@ -96,12 +96,12 @@ type Functions() =
 
         let config = FunctionImpls.readConfig()
 
-
         request.boardId |> lookupCalendarForBoard config.roommateConfig
                         |> function
                             | None -> Error  "Unknown board"
                             | Some calId -> Ok calId
                         |> Result.bind (createCalendarEvent logFn config startTime endTime)
+                        |> Result.bind (fun _ -> FunctionImpls.sendAnUpdateToBoard request.boardId logFn)
                         |> function
                             | Error e -> logFn e
                             | _ -> ()

--- a/roommate-lambda/FunctionImpls.fs
+++ b/roommate-lambda/FunctionImpls.fs
@@ -1,0 +1,50 @@
+namespace RoommateLambda
+
+open System
+open System.Net
+
+open Amazon.Lambda.Core
+open Amazon.Lambda.APIGatewayEvents
+
+open Roommate
+open Roommate
+open Roommate.SecretReader
+
+open Roommate.RoommateLogic
+module FunctionImpls =
+    open Roommate.RoommateConfig
+
+    let readConfig () : LambdaConfiguration =
+        {
+            roommateConfig = readSecretFromEnv "roommateConfig" |> RoommateConfig.deserializeConfig
+            serviceAccountEmail = readSecretFromEnv "serviceAccountEmail"
+            serviceAccountPrivKey = readSecretFromEnv "serviceAccountPrivKey"
+            serviceAccountAppName = readSecretFromEnv "serviceAccountAppName"
+            mqttEndpoint = readSecretFromEnv "mqttEndpoint"
+            webhookUrl = readSecretFromEnv "webhookUrl"
+        }
+
+
+    let sendAnUpdateToCal logFn (calId:LongCalId) =
+
+        let config = readConfig()
+        calId
+            |> (fetchEventsForCalendar logFn config)
+            |> Result.bind (mapEventsToMessage)
+            |> Result.bind (determineTopicsToPublishTo logFn config.roommateConfig)
+            |> Result.bind (sendMessageToTopics logFn config.mqttEndpoint)
+
+    let sendAnUpdateToBoard (boardId:string) logFn =
+
+        let config = readConfig()
+
+        sprintf "Sending an update for %s" boardId |> logFn
+
+        boardId
+            |> lookupCalendarForBoard config.roommateConfig
+            |> function
+                | None -> Error  "Unknown board"
+                | Some calId -> Ok calId
+            |> Result.bind (sendAnUpdateToCal logFn)
+
+

--- a/roommate-lambda/roommate-lambda.fsproj
+++ b/roommate-lambda/roommate-lambda.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="FunctionImpls.fs" />
     <Compile Include="Function.fs" />
   </ItemGroup>
 

--- a/roommate-tool/Program.fs
+++ b/roommate-tool/Program.fs
@@ -196,7 +196,7 @@ let main argv =
 
             match result with
             | Ok r ->
-                printfn "created:"
+                printfn "created: %s" (r.Id)
                 printfn ""
                 printfn "%s" (summarizeEvent r)
             | Error reason ->

--- a/roommate-tool/Program.fs
+++ b/roommate-tool/Program.fs
@@ -194,9 +194,14 @@ let main argv =
             let finish = System.DateTime.Now.AddHours(12.0).AddMinutes(15.0)
             let result = (GoogleCalendarClient.createEvent calendarService config.myCalendar roomToInvite.calendarId start finish |> Async.RunSynchronously)
 
-            printfn "created:"
-            printfn ""
-            printfn "%s" (summarizeEvent result)
+            match result with
+            | Ok r ->
+                printfn "created:"
+                printfn ""
+                printfn "%s" (summarizeEvent r)
+            | Error reason ->
+                printfn "failed to create event."
+                printfn "%s" reason
 
         if results.Contains Update_Event then
             let eventId = results.GetResult Update_Event

--- a/roommate.test/CalendarWatcherTest.fs
+++ b/roommate.test/CalendarWatcherTest.fs
@@ -6,8 +6,7 @@ open Roommate
 
 module CalendarWatcherTest =
     open Google.Apis.Calendar.v3.Data
-    open Google.Apis.Calendar.v3.Data
-    open Google.Apis.Calendar.v3.Data
+    open Roommate
     open Roommate.RoommateLogic
     open Roommate.TimeUtil
 
@@ -15,7 +14,7 @@ module CalendarWatcherTest =
     let ``parses calendar ID from URI``() =
         // from X-Goog-Resource-URI header in push notification
         let uri = "https://www.googleapis.com/calendar/v3/calendars/atomicobject.com_234523452345@resource.calendar.google.com/events?maxResults=250&alt=json"
-        calIdFromURI uri |> should equal (RoommateConfig.LongCalId "atomicobject.com_234523452345@resource.calendar.google.com")
+        RoommateConfig.calIdFromURI uri |> should equal (RoommateConfig.LongCalId "atomicobject.com_234523452345@resource.calendar.google.com")
 
 
     [<Fact>]

--- a/roommate.test/RoommateLogicTest.fs
+++ b/roommate.test/RoommateLogicTest.fs
@@ -4,7 +4,7 @@ open Xunit
 open FsUnit
 open Roommate
 
-module CalendarWatcherTest =
+module RoommateLogicTest =
     open Google.Apis.Calendar.v3.Data
     open Roommate
     open Roommate.RoommateLogic

--- a/roommate.test/roommate.test.fsproj
+++ b/roommate.test/roommate.test.fsproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="CalendarWatcherTest.fs" />
+    <Compile Include="RoommateLogicTest.fs" />
     <Compile Include="FakeBoardTest.fs" />
     <Compile Include="TimeUtilTest.fs" />
     <Compile Include="RoommateConfigTest.fs" />

--- a/roommate/GoogleCalendarClient.fs
+++ b/roommate/GoogleCalendarClient.fs
@@ -212,24 +212,12 @@ module GoogleCalendarClient =
         async {
             // first we get the event from the target room's calendar
             let! roomEvent = calendarService.Events.Get(roomCalId,roommateEventId).ExecuteAsync() |> Async.AwaitTask
-            let roommateEventReq = calendarService.Events.List(roommateCalId)
-            roommateEventReq.TimeMin <- (roomEvent.Start.DateTime)
-            roommateEventReq.MaxResults <- Nullable 50
-            let! roommateEvents = roommateEventReq.ExecuteAsync() |> Async.AwaitTask
+            let roommateEvent = calendarService.Events.Get(roommateCalId,roommateEventId).Execute()
 
-            printfn "room event %s" (Newtonsoft.Json.JsonConvert.SerializeObject(roomEvent))
-//            printfn "looking for attendee %s" roomCalId
+//            printfn "room event %s" (Newtonsoft.Json.JsonConvert.SerializeObject(roomEvent))
+//            printfn "roommate event: %s" (Newtonsoft.Json.JsonConvert.SerializeObject(roommateEvent))
 
-            // then we query events on the _roommate_ calendar that has this room as an attendee
-            let eventsWithAttendee= roommateEvents.Items |> Seq.where (fun e -> containsAttendee e roomCalId)
-            printfn "found %d events with attendee" (eventsWithAttendee |> Seq.length)
-            let roommateEvent = eventsWithAttendee |> Seq.find (fun e -> (approxEqual e.Start.DateTime.Value roomEvent.Start.DateTime.Value) && (approxEqual e.End.DateTime.Value roomEvent.End.DateTime.Value))
-            printfn "found the event! %s" (Newtonsoft.Json.JsonConvert.SerializeObject(roommateEvent))
-
-            let roommateEvent2 = calendarService.Events.Get(roommateCalId,roommateEventId).Execute()
-            printfn "or, fetched directly: %s" (Newtonsoft.Json.JsonConvert.SerializeObject(roommateEvent2))
-
-            // and edit _that_ event (which will send an update to the room, which may accept/decline the change)
+            // edit the event (which will send an update to the room, which may accept/decline the change)
             roommateEvent.Start.DateTime <- System.Nullable start
             roommateEvent.End.DateTime <- System.Nullable finish
             let! editResult = editEvent calendarService roommateCalId roommateEvent

--- a/roommate/RoommateConfig.fs
+++ b/roommate/RoommateConfig.fs
@@ -70,7 +70,7 @@ module RoommateConfig =
                 | None -> []
 
     let calIdFromURI (calURI:string) =
-        calURI.Split('/') |> List.ofArray |> List.find (fun x -> x.Contains "@")
+        calURI.Split('/') |> List.ofArray |> List.find (fun x -> x.Contains "atomicobject.com") |> LongCalId
 
     let shortName (calName:string) =
         calName.Split('(') |> List.ofArray |> List.head |> (fun s -> s.Trim())

--- a/roommate/RoommateLogic.fs
+++ b/roommate/RoommateLogic.fs
@@ -61,9 +61,9 @@ module RoommateLogic =
         printfn "found %d roommate events." (roommateEvents |> Seq.length)
 
         let adjacentEvent = roommateEvents |> Seq.tryFind (fun e ->
-            printfn "checking event %s %s" (e.range.start.ToString("o")) (e.range.finish.ToString("o"))
+//            printfn "checking event %s %s" (e.range.start.ToString("o")) (e.range.finish.ToString("o"))
             let distance = (e.range.finish - desiredTimeRange.start).Duration()
-            printfn "it seems to be %s away from %s" (distance.ToString()) (desiredTimeRange.start.ToString("o"))
+//            printfn "it seems to be %s away from %s" (distance.ToString()) (desiredTimeRange.start.ToString("o"))
             distance < System.TimeSpan.FromMinutes 2.0
             )
 

--- a/roommate/RoommateLogic.fs
+++ b/roommate/RoommateLogic.fs
@@ -60,10 +60,9 @@ module RoommateLogic =
 
         printfn "found %d roommate events." (roommateEvents |> Seq.length)
 
+        // todo: Seq.where (there may be multiple!)
         let adjacentEvent = roommateEvents |> Seq.tryFind (fun e ->
-//            printfn "checking event %s %s" (e.range.start.ToString("o")) (e.range.finish.ToString("o"))
             let distance = (e.range.finish - desiredTimeRange.start).Duration()
-//            printfn "it seems to be %s away from %s" (distance.ToString()) (desiredTimeRange.start.ToString("o"))
             distance < System.TimeSpan.FromMinutes 2.0
             )
 
@@ -74,7 +73,7 @@ module RoommateLogic =
         else if desiredTimeRange.start > (System.DateTime.UtcNow.AddHours 3.0) then
             (Nothing "cannot create event >3 hours in the future")
         else if adjacentEvent.IsSome then
-            printfn "found adjacent event %s-%s" (adjacentEvent.Value.range.start.ToString()) (adjacentEvent.Value.range.finish.ToString())
+            printfn "found event on roommate's calendar adjacent to requested range."
             (UpdateEvent (adjacentEvent.Value.gcalId,adjacentEvent.Value.range.start,desiredTimeRange.finish))
         else if (events |> List.tryFind (fun e -> timeRangeIntersects e.range desiredTimeRange)).IsSome then
             (Nothing "busy")

--- a/roommate/roommate.fsproj
+++ b/roommate/roommate.fsproj
@@ -14,7 +14,7 @@
     <Compile Include="FakeBoard.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.IotData" Version="3.3.0.83" />
+    <PackageReference Include="AWSSDK.IotData" Version="3.3.0.84" />
     <PackageReference Include="Google.Apis.Calendar.v3" Version="1.38.0.1508" />
     <PackageReference Include="newtonsoft.json" Version="12.0.1" />
   </ItemGroup>


### PR DESCRIPTION
This PR reorganizes a little, and improves initial event creation by polling until the event is accepted, then sending an update down to the board.

(next up: doing similar with editing an existing event)